### PR TITLE
Added username and privacy_policy_accepted fields to profile data

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -37,8 +37,10 @@ def existing_user(request):
     request.existing_user = create_user_in_database(
         mozwebqa, MockUser(
             email=testuser['email'],
-            username=testuser['email'].split('@')[0],
-            password=testuser['pass']
+            password=testuser['pass'],
+            profile={'name': 'mozwebqa_testuser',
+                     'username': testuser['email'].split('@')[0],
+                     'privacy_policy_accepted': True}
         )
     )
 

--- a/mocks/mock_user.py
+++ b/mocks/mock_user.py
@@ -12,10 +12,11 @@ class MockUser(dict):
 
         now = str(datetime.datetime.now())
         self['id'] = None
-        self['username'] = 'mozwebqauser%s' % now.split()[0]
         self['email'] = 'testuser@mozwebqa.com'
         self['password'] = 'p@ssw0rd'
-        self['profile'] = {'name': 'MozWebQA User- ' + now}
+        self['profile'] = {'name': 'MozWebQA User- ' + now,
+                           'username': 'mozwebqauser%s' % now.split()[0],
+                           'privacy_policy_accepted': False}
 
         self.update(**kwargs)
 

--- a/utils/oneanddone_api.py
+++ b/utils/oneanddone_api.py
@@ -58,9 +58,10 @@ class OneAndDoneAPI:
     def create_user(self, user):
         uri = 'api/v1/user'
         post_data = {
-            u'username': unicode(user['username']),
             u'email': unicode(user['email']),
-            u'profile': {u'name': unicode(user['profile']['name'])}
+            u'profile': {u'name': unicode(user['profile']['name']),
+                         u'username': unicode(user['profile']['username']),
+                         u'privacy_policy_accepted': user['profile']['privacy_policy_accepted']}
         }
         user['id'], response_text = self._do_post(uri, post_data, True)
         user['profile']['name'] = response_text['profile']['name']


### PR DESCRIPTION
Fixes `test_that_name_of_existing_user_appears_on_login` on merging https://github.com/mozilla/oneanddone/pull/147
