### PR TITLE
one and done #41 - test task details

### DIFF
--- a/pages/tasks/task_details.py
+++ b/pages/tasks/task_details.py
@@ -11,6 +11,7 @@ from pages.tasks.task_feedback import TaskFeedbackPage
 class TaskDetailsPage(Base):
 
     _name_locator = (By.CSS_SELECTOR, '.content-container > h1')
+    _team_link_locator = (By.CSS_SELECTOR, 'a[href*="team"]')
 
     _abandon_task_button_locator = (By.ID, 'abandon-task')
     _complete_task_button_locator = (By.ID, 'complete-task')
@@ -37,6 +38,11 @@ class TaskDetailsPage(Base):
         from pages.home import HomePage
         return HomePage(self.base_url, self.selenium).wait_for_page_to_load()
 
+    def click_team(self):
+        self.selenium.find_element(*self._team_link_locator).click()
+        from pages.tasks.team_details import TeamDetailsPage
+        return TeamDetailsPage(self.base_url, self.selenium).wait_for_page_to_load()
+
     @property
     def is_abandon_task_button_visible(self):
         return self.is_element_visible(self._abandon_task_button_locator)
@@ -56,3 +62,7 @@ class TaskDetailsPage(Base):
     @property
     def name(self):
         return self.selenium.find_element(*self._name_locator).text
+
+    @property
+    def team(self):
+        return self.selenium.find_element(*self._team_link_locator).text

--- a/pages/tasks/team_details.py
+++ b/pages/tasks/team_details.py
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import Base
+
+
+class TeamDetailsPage(Base):
+
+    _page_heading = (By.CSS_SELECTOR, '.content-container > h2')
+
+    @property
+    def page_heading(self):
+        return self.selenium.find_element(*self._page_heading).text

--- a/tests/test_task_details.py
+++ b/tests/test_task_details.py
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.home import HomePage
+
+
+class TestTaskDetails():
+
+    @pytest.mark.nondestructive
+    def test_that_person_can_view_task_details(self, base_url, selenium):
+        home_page = HomePage(base_url, selenium).open()
+        assert not home_page.is_user_logged_in
+
+        task = home_page.suggested_first_tasks[0]
+        task_name = task.name
+        task_details = task.click()
+        assert task_name == task_details.name
+
+        assert task_details.is_get_started_button_visible
+        assert not task_details.is_abandon_task_button_visible
+        assert not task_details.is_complete_task_button_visible
+        assert not task_details.is_save_for_later_button_visible
+
+        team_name = task_details.team
+        assert team_name
+        team_details = task_details.click_team()
+        assert team_name in team_details.page_heading


### PR DESCRIPTION
This has all the changes based on the discussion in pr #49. I squashed the commits into one since I'm starting a new pr. Most recent changes are to select team link by href contains 'team' and to change team_details page to use the page header (and then an assert name in header in the test). Also removed page title from the team_details page because there isn't a clean way to get the team name right now.